### PR TITLE
Fix animaltype in seed data

### DIFF
--- a/data.sql
+++ b/data.sql
@@ -30,7 +30,7 @@ INSERT INTO animal (animalid, animaltype, createdby, createddate, lastmodifiedby
                 (3, 'monkey', 'SYSTEM', CURRENT_TIMESTAMP, 'SYSTEM', CURRENT_TIMESTAMP),
                 (4, 'penguin', 'SYSTEM', CURRENT_TIMESTAMP, 'SYSTEM', CURRENT_TIMESTAMP),
                 (5, 'tiger', 'SYSTEM', CURRENT_TIMESTAMP, 'SYSTEM', CURRENT_TIMESTAMP),
-                (6, 'bear', 'SYSTEM', CURRENT_TIMESTAMP, 'SYSTEM', CURRENT_TIMESTAMP),
+                (6, 'giraffe', 'SYSTEM', CURRENT_TIMESTAMP, 'SYSTEM', CURRENT_TIMESTAMP),
                 (7, 'turtle', 'SYSTEM', CURRENT_TIMESTAMP, 'SYSTEM', CURRENT_TIMESTAMP);
 
 INSERT INTO zooanimals (zooid, animalid, createdby, createddate, lastmodifiedby, lastmodifieddate)


### PR DESCRIPTION
This PR fixes an issue with the seed data that conflicts with the ability to set the field `animaltype` to `unique = true`, which should be used to minimize multiple entries.

Animal type `bear` is used twice, this fixes that.